### PR TITLE
Change Docker Hub action

### DIFF
--- a/.github/workflows/dockerhub_registry.yml
+++ b/.github/workflows/dockerhub_registry.yml
@@ -2,7 +2,8 @@ name: CI to Docker Hub
 
 on:
   push:
-    branches: [ master ]
+    tags:
+      - "v*.*.*"
   workflow_dispatch:
 
 jobs:
@@ -13,6 +14,9 @@ jobs:
     
       - name: Check Out Repo 
         uses: actions/checkout@v2
+
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v1
@@ -40,7 +44,7 @@ jobs:
           file: ./Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
           push: true
-          tags: lfulcrum/simplewhale:latest
+          tags: lfulcrum/simplewhale:$RELEASE_VERSION
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
 


### PR DESCRIPTION
Only build and release docker images when a branch (the master branch)
is tagged).